### PR TITLE
"Basis" for rewrite rules

### DIFF
--- a/docs/literate/showcase.jl
+++ b/docs/literate/showcase.jl
@@ -1,0 +1,47 @@
+# # Showcasing AlgebraicABMs features
+# 
+# This file is an incomplete showcase of some less obvious features in 
+# AlgebraicABMs. It is not an intro-tutorial (the other demos are more geared 
+# towards that). To begin, we want to load our packages with `using
+
+using AlgebraicABMs, Catlab, AlgebraicRewriting
+ENV["JULIA_DEBUG"] = "AlgebraicABMs"; # turn off @debug messages for this package
+
+# ## Basis 
+
+# Rewrote rules have associated timers which are scheduled to fire in the future.
+# For normal rules, at any point in time, there is exactly one such timer per 
+# match morphism from the pattern $L$ of the rule into the present state of the 
+# world, $X$. This is often what we want, though in some circumstances, we want the 
+# 'per-what?' of the rule to be something different from the pattern. Thus we 
+# have the ability to explicitly give a *basis* for the rule, given as a 
+# map $B \rightarrowtail L$ into the rule's pattern. The rule will have timers 
+# per every 'match' $B \rightarrow X$ (which is just a *partial* match 
+# $L \nrightarrow X$). Once it's time to fire, the rest of the match is 
+# completed at random (if possible, otherwise nothing happens).
+
+# For example, we may want to associate the timers of an infection process with 
+# simply the infected people, even though the pattern of an infection rule is 
+# a suceptible + an infected person. E.g. "every infected person tries to infect
+# *someone* once per day", which would not be affected by how many susceptible 
+# people there are. Let's demonstrate this:
+
+@present SchSI(FreeSchema) begin
+  (S,I)::Ob
+end
+
+@acset_type SI(SchSI)
+
+si   = @acset SI begin S=1; I=1 end 
+i    = @acset SI begin I=1 end 
+ii   = @acset SI begin I=2 end 
+init = @acset SI begin S=10000;I=1 end 
+inf_rule = Rule(homomorphism(i, si), homomorphism(i, ii; any=true))
+basis_hom = homomorphism(i, si) # our actual basis is just a single infected
+
+abm_rule = ABMRule(inf_rule, DiscreteHazard(1); basis = basis_hom)
+abm = ABM([abm_rule])
+run!(abm, init; maxevent=3);
+
+# We can see that after the first timestep there is 1 infection, then 2 on the 
+# next timestep, then four on the next one.

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -54,6 +54,7 @@ makedocs(
   pages=Any[
     "AlgebraicABMs.jl"=>"index.md",
     "Examples"=>Any[
+     "generated/showcase.md",
       "generated/sir_petri.md",
       "generated/game_of_life.md",
       "generated/lotka_volterra.md",

--- a/src/Upstream.jl
+++ b/src/Upstream.jl
@@ -4,6 +4,8 @@ module Upstream
 using Catlab, AlgebraicRewriting
 import Catlab: is_isomorphic, Presentation
 using AlgebraicRewriting.Rewrite.Migration: pres_hash
+import AlgebraicRewriting: IncHomSet
+using AlgebraicRewriting.Incremental.IncrementalConstraints: AC, PAC, NAC
 using CompetingClocks: FirstToFire, disable!, next
 using Distributions: AbstractRNG
 
@@ -28,6 +30,20 @@ end
 
 # Upstream to AlgRewriting
 ##########################
+"""Optionally use a different pattern than the L of the rule"""
+function IncHomSet_basis(rule::Rule{T}, state::ACSet, additions=ACSetTransformation[]; 
+                         basis=nothing) where T
+  pac, nac = [], []
+  dpo = (T == :DPO) ? [left(rule)] : ACSetTransformation[]
+  right(rule) ∈ additions || push!(additions, right(rule))
+  for c in AC.(rule.conditions, Ref(additions), Ref(dpo))
+    c isa PAC && push!(pac, c)
+    c isa NAC && push!(nac, c)
+  end
+  pat = isnothing(basis) ? codom(left(rule)) : basis
+  IncHomSet(pat, additions, state; monic=rule.monic, pac, nac)
+end
+
 
 # CompetingClocks
 #################

--- a/src/Visualization.jl
+++ b/src/Visualization.jl
@@ -1,7 +1,9 @@
 module Visualization
 
+export graphviz_write
+
 import AlgebraicRewriting: view_traj 
-using Catlab: codom, right
+using Catlab: codom, right, to_graphviz
 
 using ..ABMs
 using ..ABMs: Traj
@@ -28,5 +30,13 @@ function Base.view(t::Traj, viewer; dirname="default")
     G
   end
 end 
+
+function graphviz_write(x, dirname="default")
+  G = to_graphviz(x)
+  open(dirname, "w") do io
+    show(io, "image/svg+xml", G)
+  end
+  G
+end
 
 end # module

--- a/test/ABMs.jl
+++ b/test/ABMs.jl
@@ -62,8 +62,28 @@ create_vert = ABMRule(Rule(id(Graph()),  create(Graph(1))), DiscreteHazard(1.));
 abm = ABM([create_loop, create_vert]);
 traj = run!(abm, Graph(); maxtime=5);
 
-# ODEs
-######
+
+# Basis
+#######
+using AlgebraicABMs, Catlab, AlgebraicRewriting
+
+# Rule which fires once per vertex (it tries to add an edge to an 
+# arbitrary other vertex) - rate is based on vertex pattern, not pattern for 
+# the rule itself, which has two 
+add_edge = ABMRule(Rule(id(Graph(2)), 
+                        homomorphism(Graph(2), path_graph(Graph, 2); 
+                                     any=true, monic=true)),
+                   DiscreteHazard(1.),
+                   basis=homomorphism(Graph(1), Graph(2); any=true))
+abm = ABM([add_edge])
+rt = RuntimeABM(abm, Graph(3))
+traj = run!(abm, Graph(3); maxtime=3);
+
+view(traj, graphviz_write)
+
+
+# ODEs (IN PROGRESS)
+#####################
 using AlgebraicABMs, AlgebraicRewriting, Catlab
 
 # State of world: a set of free-floating Float64s 


### PR DESCRIPTION
This PR implements using an optional extra piece of data, $B \rightarrow L$, which controls the timing of rewrites by restricting the notion of 'match' to be for a subobject of $L$. 