### PR TITLE
#32: Fix DiscreteHazard firing multiple times per timestep

### DIFF
--- a/src/ABMs.jl
+++ b/src/ABMs.jl
@@ -554,6 +554,10 @@ function run!(abm::ABM, rt::RuntimeABM, output::Traj;
       # if no event at this time was actionable, due to dangling condition
       isempty(update_data) && continue 
 
+      # Track which (rule, key) pairs are enabled during the update phase,
+      # so we can avoid duplicate re-enabling of fired matches at the end.
+      updated_keys = Set{Pair{Int, Maybe{KeyType}}}()
+
       # All other rules can potentially update in response to the current event
       for (i, (ruleᵢ, clocksᵢ)) in enumerate(zip(abm.rules, rt.clocks))
         pt = pattern_type(ruleᵢ)
@@ -569,6 +573,7 @@ function run!(abm::ABM, rt::RuntimeABM, output::Traj;
 
             for a in del_new
               enable!′(clocksᵢ[a], i, a) 
+              push!(updated_keys, i => a)
             end
             add_invalid, add_new = addition!(clocksᵢ, rule_right, rmap, rght)
 
@@ -576,7 +581,18 @@ function run!(abm::ABM, rt::RuntimeABM, output::Traj;
               (i=>d) ∈ (events) || disable!′(i => d) # (event,key) already diabled
             end
             for a in add_new
-              enable!′(clocksᵢ[a], i, a) 
+              # Check if this newly-discovered match duplicates one already
+              # enabled (can occur when expression binding creates a new state
+              # object that is isomorphic to the old one).
+              new_match = clocksᵢ[a]
+              is_dup = any(updated_keys) do rk
+                first(rk) == i && haskey(clocksᵢ, last(rk)) &&
+                  clocksᵢ[last(rk)] == new_match
+              end
+              if !is_dup
+                enable!′(clocksᵢ[a], i, a)
+              end
+              push!(updated_keys, i => a)
             end
           end
         elseif pt isa RepresentableP
@@ -595,10 +611,19 @@ function run!(abm::ABM, rt::RuntimeABM, output::Traj;
           end
         end
       end
-      # If any of the matches that were fired are still preserved, re-enable
+      # If any of the matches that were fired are still preserved, re-enable,
+      # but only if an equivalent match was not already enabled above.
       for (event, key) in events
         if haskey(rt.clocks[event], key)
-          enable!′(rt.clocks[event][key], event, key)
+          match = rt.clocks[event][key]
+          already_enabled = any(updated_keys) do rk
+            first(rk) == event && haskey(rt.sampler.transition_entry, rk) &&
+              haskey(rt.clocks[event], last(rk)) &&
+              rt.clocks[event][last(rk)] == match
+          end
+          if !already_enabled
+            enable!′(match, event, key)
+          end
         end
       end
     end

--- a/test/ABMs.jl
+++ b/test/ABMs.jl
@@ -9,6 +9,14 @@ using Catlab, AlgebraicRewriting
 using AlgebraicABMs.ABMs: RegularP, EmptyP, RepresentableP, RuntimeABM
 using AlgebraicRewriting.Incremental.IncrementalCC: match_vect
 
+@present SchCounter(FreeSchema) begin
+  X::Ob
+  N::AttrType
+  count::Attr(X, N)
+end
+@acset_type CounterSet(SchCounter){Int}
+const CounterCat = ACSetCategory(MADVarACSetCat(CounterSet()))
+
 # L = ∅, I = ∅, R = •↺
 create_loop = ABMRule(
   :CreateLoop,
@@ -79,6 +87,19 @@ traj = run!(ABM([rem_edge]), G);
 
 traj = run!(ABM([add_loop]), G);
 @test length(traj) > 3 # after we add a loop, the match persists + is resampled
+
+counter = @acset CounterSet begin X=1; N=1; count=[AttrVar(1)] end
+increment = ABMRule(
+  :Increment,
+  Rule(id(counter), id(counter); expr=(N=[vs -> only(vs) + 1],), cat=CounterCat),
+  DiscreteHazard(1.)
+)
+let init = @acset CounterSet begin X=1; count=[0] end
+  traj = run!(ABM([increment]), init; maxtime=3.0)
+  @test length(traj) == 3
+  @test first.(traj.events) == [1.0, 2.0, 3.0]
+  @test codom(right(traj.hist[end]))[:count] == [3]
+end
 
 
 


### PR DESCRIPTION
## Problem
`DiscreteHazard` rules can be scheduled more than once in the same timestep when a fired match persists after the rewrite. This shows up most readily with attribute-containing schemas.

The failure mode is that the incremental hom-set update can discover the same logical match under a new key during the addition phase, and then the later re-enable step can also re-enable the original fired key. That leaves two sampler entries for one logical match. With Dirac-style discrete hazards, both entries fire at the same time, so the number of events can grow explosively across timesteps (`1, 2, 4, 8, ...`).

## Fix
This patch tracks which `(rule, key)` entries have already been re-enabled during the update pass.

When `add_new` discovers a match, the code now checks whether an equivalent match was already enabled for that rule and skips the duplicate if so. Likewise, when previously fired matches are re-enabled at the end of the simultaneous-event update, the code checks whether an equivalent match was already scheduled during the update pass and avoids scheduling it twice.

In other words, the sampler keeps one entry per logical match, even if the incremental hom-set temporarily represents that match with multiple keys.

## Testing
- added regression coverage for the repeated-firing scenario reported in `#32`
- ran `julia --project -e 'using Pkg; Pkg.instantiate(); include("test/ABMs.jl")'`

Closes #32.
