### PR TITLE
Fix pull_back compose crash for simultaneous events

### DIFF
--- a/src/ABMs.jl
+++ b/src/ABMs.jl
@@ -536,13 +536,10 @@ function run!(abm::ABM, rt::RuntimeABM, output::Traj;
         for (l, r) in first.(update_data)
           pb = pull_back(l, m)
           if isnothing(pb)
-            @debug "Skipping event $(name(rule)): match invalidated by prior simultaneous event"
-            m = nothing
-            break
+            error("Conflicting simultaneous events: rule $(getname(event)) was invalidated by a prior simultaneous rewrite at t=$(round(rt.tnow, digits=2)).")
           end
           m = pb ⋅ r
         end
-        isnothing(m) && continue
         dpo = rule_type == :DPO ? (left(rule′), m) : nothing
         # check if dangling condition is satisfied
         isnothing(dpo) || can_pushout_complement(ComposablePair(dpo...)) || continue

--- a/src/ABMs.jl
+++ b/src/ABMs.jl
@@ -534,8 +534,15 @@ function run!(abm::ABM, rt::RuntimeABM, output::Traj;
                       basis=basis(rule))
         # bring the match 'up to speed' given the previous (simultanous) updates
         for (l, r) in first.(update_data)
-          m = pull_back(l, m) ⋅ r
+          pb = pull_back(l, m)
+          if isnothing(pb)
+            @debug "Skipping event $(name(rule)): match invalidated by prior simultaneous event"
+            m = nothing
+            break
+          end
+          m = pb ⋅ r
         end
+        isnothing(m) && continue
         dpo = rule_type == :DPO ? (left(rule′), m) : nothing
         # check if dangling condition is satisfied
         isnothing(dpo) || can_pushout_complement(ComposablePair(dpo...)) || continue

--- a/test/ABMs.jl
+++ b/test/ABMs.jl
@@ -88,6 +88,19 @@ create_vert = ABMRule(Rule(id(Graph()),  create(Graph(1))), DiscreteHazard(1.));
 abm = ABM([create_loop, create_vert]);
 traj = run!(abm, Graph(); maxtime=5);
 
+let rem_loop_a = ABMRule(:RemLoopA, Rule(delete(Graph(1)), id(Graph(1))), DiscreteHazard(1.)),
+    rem_loop_b = ABMRule(:RemLoopB, Rule(delete(Graph(1)), id(Graph(1))), DiscreteHazard(1.)),
+    loop_graph = @acset Graph begin V=1; E=1; src=[1]; tgt=[1] end
+  err = try
+    run!(ABM([rem_loop_a, rem_loop_b]), loop_graph; maxtime=1.0)
+    nothing
+  catch e
+    e
+  end
+  @test err isa ErrorException
+  @test occursin("Conflicting simultaneous events", sprint(showerror, err))
+end
+
 
 # Basis
 #######


### PR DESCRIPTION
## Problem
When multiple simultaneous events are processed in one timestep, the runtime tries to update each pending match so it reflects rewrites that already happened earlier in the same batch.

That update step does `pull_back(l, m) ⋅ r`. If one simultaneous event invalidates another events match, `pull_back(l, m)` returns `nothing`. Before this PR, that led to a cryptic composition failure instead of a clear explanation that the batch of simultaneous events was internally inconsistent.

## Fix
This PR now treats that situation as a genuine conflict in the simultaneous-event set and raises a clear error by default.

When a later simultaneous event can no longer be updated because a prior rewrite invalidated its match, `run!` now throws an `ErrorException` explaining that conflicting simultaneous events were encountered and identifying the invalidated rule.

This keeps the failure mode explicit and reviewable instead of silently skipping work or crashing with a lower-level `MethodError`.

## Testing
- added a regression test with two simultaneous `DiscreteHazard(1.)` loop-removal rules on the same one-loop graph
- the test asserts that the run fails with a helpful `"Conflicting simultaneous events"` error message
