### PR TITLE
fix: respect maxevent when maxtime is finite

### DIFF
--- a/docs/literate/game_of_life.jl
+++ b/docs/literate/game_of_life.jl
@@ -416,7 +416,7 @@ match_coords(birth, G)
 # This is easy! Pass in our model and our initial state. We optionally could 
 # limit the run via some maximum number of steps or time, but this one will 
 # achieve steady state within 3 time steps.
-res = run!(GoL_coords, G);
+res = run!(GoL_coords, G; maxevent=100);
 @test length(res) == 13
 
 # ## View results

--- a/src/ABMs.jl
+++ b/src/ABMs.jl
@@ -470,7 +470,7 @@ Base.isempty(t::Traj) = isempty(t.events)
 
 Base.length(t::Traj) = length(t.events)
 
-const MAXEVENT = 100
+const MAXEVENT = typemax(Int)
 
 """
 Run an ABM, creating a fresh runtime + trajectory.
@@ -480,12 +480,18 @@ dt - timestep for checking discrete events when running ODE dynamics.
 """
 function run!(abm::ABM, init::T; save=_->nothing, maxevent=MAXEVENT, 
               maxtime=Inf, kw...) where T<:ACSet 
+  maxevent == typemax(Int) && isinf(maxtime) && error(
+    "run! requires at least one finite bound; specify maxevent and/or maxtime."
+  )
   run!(abm::ABM, RuntimeABM(abm, init; kw...), Traj(init); 
        save, maxtime, maxevent)
 end
 
 function run!(abm::ABM, rt::RuntimeABM, output::Traj;
               save=_->nothing, maxevent=MAXEVENT, maxtime=Inf, dt=0.1)
+  maxevent == typemax(Int) && isinf(maxtime) && error(
+    "run! requires at least one finite bound; specify maxevent and/or maxtime."
+  )
   # Helper functions that automatically incorporate the runtime `rt`
   getname(rule::Int)::String = 
     string(isnothing(abm.rules[rule].name) ? rule : abm.rules[rule].name)

--- a/src/ABMs.jl
+++ b/src/ABMs.jl
@@ -486,7 +486,6 @@ end
 
 function run!(abm::ABM, rt::RuntimeABM, output::Traj;
               save=_->nothing, maxevent=MAXEVENT, maxtime=Inf, dt=0.1)
-  maxevent = isinf(maxtime) ? maxevent : typemax(Int)
   # Helper functions that automatically incorporate the runtime `rt`
   getname(rule::Int)::String = 
     string(isnothing(abm.rules[rule].name) ? rule : abm.rules[rule].name)

--- a/test/ABMs.jl
+++ b/test/ABMs.jl
@@ -80,6 +80,11 @@ traj = run!(ABM([rem_edge]), G);
 traj = run!(ABM([add_loop]), G);
 @test length(traj) > 3 # after we add a loop, the match persists + is resampled
 
+let traj = run!(ABM([create_loop]), Graph(); maxevent=2, maxtime=10.0)
+  @test length(traj) == 2
+  @test traj.events[end][1] == 2.0
+end
+
 
 
 # Test events in parallel

--- a/test/ABMs.jl
+++ b/test/ABMs.jl
@@ -73,16 +73,26 @@ push!(new_abm, do_nothing)
 
 traj = run!(abm, G; maxevent=10);
 
-traj = run!(ABM([rem_edge]), G);
+traj = run!(ABM([rem_edge]), G; maxevent=10);
 @test length(traj) == 3
 
 
-traj = run!(ABM([add_loop]), G);
+traj = run!(ABM([add_loop]), G; maxevent=10);
 @test length(traj) > 3 # after we add a loop, the match persists + is resampled
 
 let traj = run!(ABM([create_loop]), Graph(); maxevent=2, maxtime=10.0)
   @test length(traj) == 2
   @test traj.events[end][1] == 2.0
+end
+
+let err = try
+    run!(ABM([create_loop]), Graph())
+    nothing
+  catch e
+    e
+  end
+  @test err isa ErrorException
+  @test occursin("specify maxevent and/or maxtime", sprint(showerror, err))
 end
 
 


### PR DESCRIPTION
## Problem
`run!` accepted both `maxevent` and `maxtime`, but previously a finite `maxtime` silently disabled the caller-supplied `maxevent` by replacing it with `typemax(Int)`.

That meant callers asking for "stop after at most N events, but no later than time T" were only getting the time bound. It also left the API with an arbitrary hidden default event cap (`100`) when no stopping criterion was supplied.

## Fix
This PR now does two things:

1. `maxevent` defaults to `typemax(Int)` rather than an arbitrary finite cap.
2. `run!` now errors if the caller leaves both bounds unbounded, i.e. `maxevent == typemax(Int)` and `maxtime == Inf`.

With that change, finite `maxevent` and finite `maxtime` compose cleanly, and calls that would otherwise run without any stopping criterion now fail with a clear message asking the caller to specify at least one bound.

## Testing
- kept the regression test showing that `maxevent=2` and `maxtime=10.0` stop after exactly two events
- added a regression test that `run!(...)` without any finite bound throws a helpful error
- updated affected tests/examples on this branch to pass an explicit bound where needed
